### PR TITLE
Fix crash related to namespace, invalid files handling and add nested namespaces.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,20 +5,23 @@ const child_process = require('child_process');
 const projectPath = '.';
 var sourcePath = path.join(projectPath, 'i18n');
 var destPath = path.join(projectPath, '.elm-i18n');
-var destNamespacePath = path.join(destPath, 'I18n');
-var moduleNamespace = 'I18n'
-
+var moduleNamespace = 'I18n';
+var destNamespacePath = path.join(destPath, moduleNamespace);
 const configJson = path.join(projectPath, 'i18n.json')
-if (fs.existsSync(configJson)) {
-    const rawJSON = fs.readFileSync(configJson);
-    const json = JSON.parse(rawJSON);
-    sourcePath = path.join(projectPath, json.source);
-    destPath = path.join(projectPath, json.dest);
-    destNamespacePath = path.join(destPath, 'I18n');
-    moduleNamespace = `${json.namespace}.${moduleNamespace}`
-}
 
 function main () {
+    if (fs.existsSync(configJson)) {
+        const rawJSON = fs.readFileSync(configJson);
+        const json = JSON.parse(rawJSON);
+        if (json.source != undefined)
+            sourcePath = path.join(projectPath, json.source);
+        if (json.dest != undefined)
+            destPath = path.join(projectPath, json.dest);
+        if (json.namespace != undefined)
+            moduleNamespace = json.namespace;
+        destNamespacePath = path.join(destPath, ...moduleNamespace.split('.'));
+    }
+
     if (!fs.existsSync(destPath))
         fs.mkdirSync(destPath);
     if (!fs.existsSync(destNamespacePath))
@@ -32,6 +35,9 @@ function main () {
         let typed = null;
 
         files.forEach(function (fileName) {
+            if(fileName.startsWith('.')) return;
+            if(!fileName.endsWith('.json')) return;
+
             let rawJSON = fs.readFileSync(path.join(sourcePath, fileName));
             let parsedJSON = JSON.parse(rawJSON.toString().replace(/\\/g, '\\\\'));
             if (typed === null)


### PR DESCRIPTION
New features:
* Makes all fields optional in configuration JSON;
* Allow nested namespaces;
* Ignore invalid files in the source directory;
* Move logic inside the main function.

New behavior:
* `"namespace"` in the setting **does not** gets autosuffixed with `.I18n`