### PR TITLE
Generate Decoders and MockLanguage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,16 +16,11 @@ jobs:
      - name: Checkout
        uses: actions/checkout@v2
 
-     - name: Setup Node
-       uses: actions/setup-node@v2.1.5
-       with:
-        node-version: '14'
-
      - name: Get yarn cache directory path
        id: yarn-cache-dir-path
        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-     - uses: actions/cache@v2.1.5
+     - uses: actions/cache@v2
        id: yarn-cache
        with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -37,7 +32,7 @@ jobs:
        run: yarn install
 
      - name: Run linter
-       run: npm run lint
+       run: yarn run lint
 
   build:
    runs-on: ubuntu-latest
@@ -47,16 +42,11 @@ jobs:
      - name: Checkout
        uses: actions/checkout@v2
 
-     - name: Setup Node
-       uses: actions/setup-node@v2.1.5
-       with:
-        node-version: '14'
-
      - name: Get yarn cache directory path
        id: yarn-cache-dir-path
        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-     - uses: actions/cache@v2.1.5
+     - uses: actions/cache@v2
        id: yarn-cache
        with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -68,4 +58,4 @@ jobs:
        run: yarn install
 
      - name: Build
-       run: npm run prepare
+       run: yarn run prepare

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -109,11 +109,11 @@ function addRecord(name: string, context: string, data: JSON, typesBuffer: Writa
                     + " } -> String"
                 );
                 decoder.push(
-                    'Decode.map (\\value '
-                    + subEntries.map((v) => asFieldName(v)).join(' ')
-                    + ' -> value |> '
-                    + subEntries.map((v) => `String.replace "{{${v}}}" ${asFieldName(v)}`).join(' |> ')
-                    + ') Decode.string'
+                    'Decode.oneOf [ Decode.map (\\value {'
+                    + subEntries.map((v) => asFieldName(v)).join(', ')
+                    + '} -> value |>\n'
+                    + subEntries.map((v) => `String.replace "{{${v}}}" ${asFieldName(v)}`).join(' |>\n')
+                    + `) (Decode.field "${key}" Decode.string),\nDecode.succeed (\\value _ -> "${context}.${key}") ]`
                 );
             }
         } else if (value !== null && typeof value == 'object') {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -95,8 +95,9 @@ type AddHelperAccumulator = {
 };
 
 function addHelper(accumulator: AddHelperAccumulator): void {
-    const {typesBuffer, decodersBuffer, mockBuffer} = accumulator;
-    let {name, context, data} = accumulator;
+    const {data, typesBuffer, decodersBuffer, mockBuffer} = accumulator;
+    let {name, context} = accumulator;
+
     const record: string[] = [];
     const decoder: string[] = [];
     const mock: string[] = [];
@@ -190,8 +191,9 @@ type AddValueAccumulator = {
 };
 
 function addValue(accumulator: AddValueAccumulator): void {
-    const buffer = accumulator.buffer;
-    let {name, data} = accumulator;
+    const {buffer, data} = accumulator;
+    let {name} = accumulator;
+
     const record: string[] = [];
 
     Object.entries(data).forEach(([key, value]) => {


### PR DESCRIPTION
#### :thinking: What?

* Generate JSON Decoders;
* Generate MockLanguage.

Details:
* MockLanguage have the terms (with context) as their values;
* JSON Decoders are type-safe;
* JSON Decoders supports custom translators for `{{replace}}` replacement;
* JSON Decoders have a per-term fallback system, so outdated JSON files don't break your app.

Non-important:
* Move to monthly updates with @dependabot;
* Dedup code related to piping to elm-format;
* Always capitalize the modules' name;
* Use "never" when program critically fails;
* Warn when non-JSON files are ignored.
