### PR TITLE
Allow manually listing languages to convert

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,5 +16,6 @@
         "@typescript-eslint"
     ],
     "rules": {
+        "prefer-template": "error"
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Create a i18n.json with the following contents:
 - `"namespace"` defaults to `"I18n"`;
 - `"generateDecoders"` defaults to `false`;
 - `"generateMockLanguage"` defaults to `false`.
-- `"languages"` defaults to `null` (`null` searches for `${source}/*.json`).
+- `"languages"` defaults to `[]` (when empty, it'll search for `${source}/*.json` instead).
 
 ## Optional features
 
 - `"generateDecoders"` generates a `Decoders.elm` with JSON decoders;
 - `"generateMockLanguage"` generates a `MockLanguage.elm` where the value of each terms reflects their own `context.key`.
-- `"languages"` chooses what files to transform, helps when using with `"generateDecoders"` for loading non-specified languages during runtime.
+- `"languages"` chooses what files to transform; helps when using with `"generateDecoders"` for loading non-specified languages during runtime.
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Generates Elm sources from i18n's JSONs.
 
 ## Instructions
 
-- Download the json from POEditor using "key - value" format.
+- Download the JSON from POEditor, using "key - value" format.
 - Save it inside an `i18n` (configurable as `"source"`) folder in your project's path.
 - Add `.elm-i18n` (configurable as `"dest"`) to `source-directories` in your `elm.json`.
 
@@ -18,7 +18,8 @@ Create a i18n.json with the following contents:
   "dest": ".elm-i18n",
   "namespace": "MyModuleName",
   "generateDecoders": true,
-  "generateMockLanguage": true
+  "generateMockLanguage": true,
+  "languages": ["English"]
 }
 ```
 
@@ -27,11 +28,13 @@ Create a i18n.json with the following contents:
 - `"namespace"` defaults to `"I18n"`;
 - `"generateDecoders"` defaults to `false`;
 - `"generateMockLanguage"` defaults to `false`.
+- `"languages"` defaults to `null` (`null` searches for `${source}/*.json`).
 
 ## Optional features
 
 - `"generateDecoders"` generates a `Decoders.elm` with JSON decoders;
 - `"generateMockLanguage"` generates a `MockLanguage.elm` where the value of each terms reflects their own `context.key`.
+- `"languages"` chooses what files to transform, helps when using with `"generateDecoders"` for loading non-specified languages during runtime.
 
 ## Running
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -262,14 +262,16 @@ function addValue(accumulator: AddValueAccumulator): void {
     } else if (typeof value == 'string') {
       const subEntries = value.match(subEntryRegex);
       if (subEntries == null) record.push(`${fieldKey} = "${value}"`);
-      else
+      else {
         const lambdaParameters = subEntries
           .map((v) => asFieldName(v))
           .join(', ');
-      const replacedSubEntry = value.replace(subEntrySed, '" ++ $1 ++ "');
-      record.push(
-        `${fieldKey} = \\{ ${lambdaParameters} } -> "${replacedSubEntry}"`,
-      );
+
+        const replacedSubEntry = value.replace(subEntrySed, '" ++ $1 ++ "');
+        record.push(
+          `${fieldKey} = \\{ ${lambdaParameters} } -> "${replacedSubEntry}"`,
+        );
+      }
     } else if (value !== null && typeof value == 'object') {
       const newRecord = name + capitalize(key);
       record.push(`${fieldKey} = ${asFieldName(newRecord)}`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,7 +19,7 @@ type Config = Partial<{
 }>;
 
 let typeGenerated: boolean | null = null;
-const buildWhatHelpers = {
+const buildConfig = {
   generateDecoders: false,
   generateMockLanguage: false,
 };
@@ -37,9 +37,9 @@ export function main(): void {
     if (json.namespace != undefined) moduleNamespace = json.namespace;
     destNamespacePath = path.join(destPath, ...moduleNamespace.split('.'));
     if (json.generateDecoders != undefined)
-      buildWhatHelpers.generateDecoders = json.generateDecoders;
+      buildConfig.generateDecoders = json.generateDecoders;
     if (json.generateMockLanguage != undefined)
-      buildWhatHelpers.generateMockLanguage = json.generateMockLanguage;
+      buildConfig.generateMockLanguage = json.generateMockLanguage;
     if (json.languages != undefined) languages = json.languages;
   }
 
@@ -67,7 +67,7 @@ export function main(): void {
   }
 }
 
-function transformFile(fileName: string) {
+function transformFile(fileName: string): void {
   console.log('Working with "' + fileName + '".');
   const rawJSON = fs.readFileSync(path.join(sourcePath, fileName));
   const parsedJSON = JSON.parse(rawJSON.toString().replace(/\\/g, '\\\\'));
@@ -82,17 +82,17 @@ function die(explanation: string): never {
 
 function buildHelpers(data: JSON): boolean {
   let announce = 'Bulding Types.elm';
-  if (buildWhatHelpers.generateDecoders) announce += ' / Decoders.elm';
-  if (buildWhatHelpers.generateMockLanguage) announce += ' / MockLanguage.elm';
+  if (buildConfig.generateDecoders) announce += ' / Decoders.elm';
+  if (buildConfig.generateMockLanguage) announce += ' / MockLanguage.elm';
   console.log(announce);
 
   const typesBuffer = pipeToElmFormat(
     path.join(destNamespacePath, 'Types.elm'),
   );
-  const decodersBuffer = buildWhatHelpers.generateDecoders
+  const decodersBuffer = buildConfig.generateDecoders
     ? pipeToElmFormat(path.join(destNamespacePath, 'Decoders.elm'))
     : null;
-  const mockBuffer = buildWhatHelpers.generateMockLanguage
+  const mockBuffer = buildConfig.generateMockLanguage
     ? pipeToElmFormat(path.join(destNamespacePath, 'MockLanguage.elm'))
     : null;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -68,36 +68,31 @@ export function main(): void {
 }
 
 function transformFile(fileName: string) {
-    console.log('Working with "' + fileName + '".');
-    const rawJSON = fs.readFileSync(path.join(sourcePath, fileName));
-    const parsedJSON = JSON.parse(rawJSON.toString().replace(/\\/g, '\\\\'));
-    if (typeGenerated === null) typeGenerated = buildHelpers(parsedJSON, buildWhatHelpers);
-    buildLang(fileName, parsedJSON);
-  }
+  console.log('Working with "' + fileName + '".');
+  const rawJSON = fs.readFileSync(path.join(sourcePath, fileName));
+  const parsedJSON = JSON.parse(rawJSON.toString().replace(/\\/g, '\\\\'));
+  if (typeGenerated === null) typeGenerated = buildHelpers(parsedJSON);
+  buildLang(fileName, parsedJSON);
+}
 
 function die(explanation: string): never {
   console.log(explanation);
   return process.exit(1);
 }
 
-type BuildWhatHelpers = {
-  generateDecoders: boolean;
-  generateMockLanguage: boolean;
-};
-
-function buildHelpers(data: JSON, what: BuildWhatHelpers): boolean {
+function buildHelpers(data: JSON): boolean {
   let announce = 'Bulding Types.elm';
-  if (what.generateDecoders) announce += ' / Decoders.elm';
-  if (what.generateMockLanguage) announce += ' / MockLanguage.elm';
+  if (buildWhatHelpers.generateDecoders) announce += ' / Decoders.elm';
+  if (buildWhatHelpers.generateMockLanguage) announce += ' / MockLanguage.elm';
   console.log(announce);
 
   const typesBuffer = pipeToElmFormat(
     path.join(destNamespacePath, 'Types.elm'),
   );
-  const decodersBuffer = what.generateDecoders
+  const decodersBuffer = buildWhatHelpers.generateDecoders
     ? pipeToElmFormat(path.join(destNamespacePath, 'Decoders.elm'))
     : null;
-  const mockBuffer = what.generateMockLanguage
+  const mockBuffer = buildWhatHelpers.generateMockLanguage
     ? pipeToElmFormat(path.join(destNamespacePath, 'MockLanguage.elm'))
     : null;
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,7 +25,7 @@ const buildWhatHelpers = {
 };
 
 export function main(): void {
-  let languages: string[] | null = null;
+  let languages: string[] = [];
 
   if (fs.existsSync(configJson)) {
     console.log('Reading config...');
@@ -46,7 +46,7 @@ export function main(): void {
   if (!fs.existsSync(destPath)) fs.mkdirSync(destPath);
   if (!fs.existsSync(destNamespacePath)) fs.mkdirSync(destNamespacePath);
 
-  if (languages === null || languages === []) {
+  if (languages.length < 1) {
     fs.readdir(sourcePath, function (err, pathFiles) {
       if (err) {
         return console.log('Unable to scan directory: ' + err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-json-to-elm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Generates Elm sources from i18n's JSONs.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
In a certain project, we have "Spanish.json" and "French.json" loading through HTTP/AJAX, we don't need to generate Elm files for them, only for "English.json" to serve as a fallback.
This won't interfere with the generation of the mock language.