### PR TITLE
Add fallback language to empty strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ i18n.json
 i18n-json-to-elm-v*.tgz
 node_modules/
 tests/
-**/*.js
+**.js

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -8,7 +8,7 @@ let sourcePath = path.join(projectPath, 'i18n');
 let destPath = path.join(projectPath, '.elm-i18n');
 let moduleNamespace = 'I18n';
 let destNamespacePath = path.join(destPath, moduleNamespace);
-let emptyFallback : string | null = null;
+let emptyFallback: string | null = null;
 const configJson = path.join(projectPath, 'i18n.json');
 type Config = Partial<{
   source: string;
@@ -240,7 +240,9 @@ function buildLang(sourceFileName: string, data: JSON): boolean {
   );
 
   if (emptyFallback && emptyFallback !== moduleName) {
-    buffer.write(`import ${moduleNamespace}.${emptyFallback} as EmptyFallback\n`);
+    buffer.write(
+      `import ${moduleNamespace}.${emptyFallback} as EmptyFallback\n`,
+    );
   }
 
   addValue({ moduleName, name: '', data, buffer });
@@ -250,7 +252,7 @@ function buildLang(sourceFileName: string, data: JSON): boolean {
 }
 
 type AddValueAccumulator = {
-  moduleName: string
+  moduleName: string;
   name: string;
   data: JSON;
   buffer: Writable;
@@ -269,8 +271,14 @@ function addValue(accumulator: AddValueAccumulator): void {
       die('Unexpected array in JSON');
     } else if (typeof value == 'string') {
       const subEntries = value.match(subEntryRegex);
-      if (value == '' && emptyFallback && emptyFallback !== accumulator.moduleName) {
-        record.push(`${fieldKey} = EmptyFallback.${asFieldName(name)}.${fieldKey}`);
+      if (
+        value == '' &&
+        emptyFallback &&
+        emptyFallback !== accumulator.moduleName
+      ) {
+        record.push(
+          `${fieldKey} = EmptyFallback.${asFieldName(name)}.${fieldKey}`,
+        );
       } else if (subEntries == null) {
         record.push(`${fieldKey} = "${value}"`);
       } else {
@@ -286,7 +294,12 @@ function addValue(accumulator: AddValueAccumulator): void {
     } else if (value !== null && typeof value == 'object') {
       const newRecord = name + capitalize(key);
       record.push(`${fieldKey} = ${asFieldName(newRecord)}`);
-      addValue({ moduleName: accumulator.moduleName, name: newRecord, data: value, buffer });
+      addValue({
+        moduleName: accumulator.moduleName,
+        name: newRecord,
+        data: value,
+        buffer,
+      });
     } else die('Invalid JSON');
   });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -243,13 +243,14 @@ function buildLang(sourceFileName: string, data: JSON): boolean {
     buffer.write(`import ${moduleNamespace}.${emptyFallback} as EmptyFallback\n`);
   }
 
-  addValue({ name: '', data, buffer });
+  addValue({ moduleName, name: '', data, buffer });
 
   buffer.end();
   return true;
 }
 
 type AddValueAccumulator = {
+  moduleName: string
   name: string;
   data: JSON;
   buffer: Writable;
@@ -268,7 +269,7 @@ function addValue(accumulator: AddValueAccumulator): void {
       die('Unexpected array in JSON');
     } else if (typeof value == 'string') {
       const subEntries = value.match(subEntryRegex);
-      if (value == '' && emptyFallback && emptyFallback !== moduleName) {
+      if (value == '' && emptyFallback && emptyFallback !== accumulator.moduleName) {
         record.push(`${fieldKey} = EmptyFallback.${asFieldName(name)}.${fieldKey}`);
       } else if (subEntries == null) {
         record.push(`${fieldKey} = "${value}"`);
@@ -285,7 +286,7 @@ function addValue(accumulator: AddValueAccumulator): void {
     } else if (value !== null && typeof value == 'object') {
       const newRecord = name + capitalize(key);
       record.push(`${fieldKey} = ${asFieldName(newRecord)}`);
-      addValue({ name: newRecord, data: value, buffer });
+      addValue({ moduleName: accumulator.moduleName, name: newRecord, data: value, buffer });
     } else die('Invalid JSON');
   });
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -268,7 +268,7 @@ function addValue(accumulator: AddValueAccumulator): void {
       die('Unexpected array in JSON');
     } else if (typeof value == 'string') {
       const subEntries = value.match(subEntryRegex);
-      if (value == '' && emptyFallback) {
+      if (value == '' && emptyFallback && emptyFallback !== moduleName) {
         record.push(`${fieldKey} = EmptyFallback.${asFieldName(name)}.${fieldKey}`);
       } else if (subEntries == null) {
         record.push(`${fieldKey} = "${value}"`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -239,7 +239,7 @@ function buildLang(sourceFileName: string, data: JSON): boolean {
       `import ${moduleNamespace}.Types exposing (..)\n`,
   );
 
-  if (emptyFallback) {
+  if (emptyFallback && emptyFallback !== moduleName) {
     buffer.write(`import ${moduleNamespace}.${emptyFallback} as EmptyFallback\n`);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "i18n-json-to-elm",
-  "version": "1.2.3",
+  "version": "1.3.0",
   "description": "Generates Elm sources from i18n's JSONs.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
#### :thinking: What?

- When generating an Elm file, replace empty strings with references for another language's terms.

#### :man_shrugging: Why?

- So I can just export them from POE Editor and do nothing else to this matter.
- Closes #111

#### :no_good: Blocked by

Nothing.

#### :clipboard: Pending

Nothing.